### PR TITLE
feat: support custom error messages

### DIFF
--- a/.chachalog/WdBQl560.md
+++ b/.chachalog/WdBQl560.md
@@ -1,0 +1,18 @@
+---
+# Describe desired version bumps
+formgator: patch
+---
+
+Add support for custom error messages. (#22)
+
+```js
+// Composable, user-friendly username schema
+const username = fg.text(
+  { minlength: 3, pattern: /^\w+$/ },
+  {
+    // Can be a function or a string
+    minlength: ({ minlength }) => `Username must be at least ${minlength} characters long`,
+    pattern: "Username can only contain letters, numbers, and underscores",
+  }
+);
+```

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import assert from "./assert.ts";
-import { type ReadonlyFormData, fail, failures } from "./definitions.ts";
+import { type ReadonlyFormData, fail, failParse } from "./definitions.ts";
 import * as fg from "./index.ts";
 
 describe("form()", () => {
@@ -32,7 +32,10 @@ describe("form()", () => {
       const result = fg.form({ input: fg.text({ maxlength: 10 }) }).safeParse(data);
 
       assert(!result.success);
-      assert.deepEqualTyped(fail(result.error.issues.input), failures.maxlength(10));
+      assert.deepEqualTyped(
+        fail(result.error.issues.input),
+        failParse("maxlength", {}, { maxlength: 10 }),
+      );
     });
   });
 
@@ -55,7 +58,10 @@ describe("form()", () => {
         assert.fail("Expected an error");
       } catch (error) {
         assert(error instanceof fg.FormgatorError);
-        assert.deepEqualTyped(fail(error.issues.input), failures.maxlength(10));
+        assert.deepEqualTyped(
+          fail(error.issues.input),
+          failParse("maxlength", {}, { maxlength: 10 }),
+        );
       }
     });
   });

--- a/src/validators/checkbox.test.ts
+++ b/src/validators/checkbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { checkbox } from "./checkbox.ts";
 
 describe("checkbox()", async () => {
@@ -16,10 +16,10 @@ describe("checkbox()", async () => {
     const data = new FormData();
     data.append("input", "invalid");
 
-    assert.deepEqualTyped(checkbox()[safeParse](data, "input"), failures.invalid());
+    assert.deepEqualTyped(checkbox()[safeParse](data, "input"), failParse("invalid", {}));
     assert.deepEqualTyped(
       checkbox({ required: true })[safeParse](data, "missing"),
-      failures.required(),
+      failParse("required", {}),
     );
   });
 });

--- a/src/validators/checkbox.ts
+++ b/src/validators/checkbox.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="checkbox">` form input validator.
@@ -11,14 +18,17 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  * instead if you want to handle several checkboxes with the same name but
  * different values.
  */
-export function checkbox(attributes: { required?: boolean } = {}): FormInput<boolean> {
+export function checkbox(
+  attributes: { required?: boolean } = {},
+  failures: Failures<"invalid" | "required"> = {},
+): FormInput<boolean> {
   return {
     ...methods,
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (value !== null && value !== "on") return failures.invalid();
-      if (attributes.required && value === null) return failures.required();
+      if (value !== null && value !== "on") return failParse("invalid", failures);
+      if (attributes.required && value === null) return failParse("required", failures);
       return succeed(value === "on");
     },
   };

--- a/src/validators/color.test.ts
+++ b/src/validators/color.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { color } from "./color.ts";
 
 describe("color()", async () => {
@@ -19,7 +19,7 @@ describe("color()", async () => {
     const data = new FormData();
     data.append("input", "invalid");
 
-    assert.deepEqualTyped(color()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(color()[safeParse](data, "missing"), failures.type());
+    assert.deepEqualTyped(color()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(color()[safeParse](data, "missing"), failParse("type", {}));
   });
 });

--- a/src/validators/color.ts
+++ b/src/validators/color.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="color">` form input validator.
@@ -7,7 +14,7 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  *
  * The output value is a string with the format `#rrggbb`.
  */
-export function color(): FormInput<`#${string}`> & {
+export function color(failures: Failures<"type" | "invalid"> = {}): FormInput<`#${string}`> & {
   /** Returns the color as a [R, G, B] 8-bit integer triplet */
   asRGB(): FormInput<[number, number, number]>;
 } {
@@ -16,8 +23,8 @@ export function color(): FormInput<`#${string}`> & {
     attributes: {},
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (!/^#[0-9a-f]{6}$/.test(value)) return failures.invalid();
+      if (typeof value !== "string") return failParse("type", failures);
+      if (!/^#[0-9a-f]{6}$/.test(value)) return failParse("invalid", failures);
       return succeed(value as `#${string}`);
     },
     asRGB() {

--- a/src/validators/custom.test.ts
+++ b/src/validators/custom.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { fail, safeParse, succeed } from "../definitions.ts";
 import { custom } from "./custom.ts";
 
 describe("custom()", async () => {
@@ -25,7 +25,13 @@ describe("custom()", async () => {
     data.append("input", "invalid");
     data.append("file", new File([], "file.txt"));
 
-    assert.deepEqualTyped(validator(data, "input"), failures.custom("Odd number of values"));
-    assert.deepEqualTyped(validator(data, "file"), failures.custom("Invalid value type"));
+    assert.deepEqualTyped(
+      validator(data, "input"),
+      fail({ code: "custom" as const, message: "Odd number of values" }),
+    );
+    assert.deepEqualTyped(
+      validator(data, "file"),
+      fail({ code: "custom" as const, message: "Invalid value type" }),
+    );
   });
 });

--- a/src/validators/custom.ts
+++ b/src/validators/custom.ts
@@ -1,7 +1,7 @@
 import {
   type FormInput,
   type ReadonlyFormData,
-  failures,
+  fail,
   methods,
   safeParse,
   succeed,
@@ -26,7 +26,7 @@ export function custom<T>(
         return succeed(fn(data, name));
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return failures.custom(message);
+        return fail({ code: "custom" as const, message });
       }
     },
   };

--- a/src/validators/date.test.ts
+++ b/src/validators/date.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { date } from "./date.ts";
 
 describe("date()", async () => {
@@ -40,17 +40,20 @@ describe("date()", async () => {
     data.append("nad", "2024-13-01");
     data.append("ok", "2024-09-30");
 
-    assert.deepEqualTyped(date()[safeParse](data, "missing"), failures.type());
-    assert.deepEqualTyped(date({ required: true })[safeParse](data, "empty"), failures.required());
-    assert.deepEqualTyped(date()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(date()[safeParse](data, "nad"), failures.invalid());
+    assert.deepEqualTyped(date()[safeParse](data, "missing"), failParse("type", {}));
+    assert.deepEqualTyped(
+      date({ required: true })[safeParse](data, "empty"),
+      failParse("required", {}),
+    );
+    assert.deepEqualTyped(date()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(date()[safeParse](data, "nad"), failParse("invalid", {}));
     assert.deepEqualTyped(
       date({ min: "2024-10-01" })[safeParse](data, "ok"),
-      failures.min("2024-10-01"),
+      failParse("min", {}, { min: "2024-10-01" }),
     );
     assert.deepEqualTyped(
       date({ max: "2024-09-29" })[safeParse](data, "ok"),
-      failures.max("2024-09-29"),
+      failParse("max", {}, { max: "2024-09-29" }),
     );
   });
 });

--- a/src/validators/date.ts
+++ b/src/validators/date.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="date">` form input validator.
@@ -11,24 +18,31 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  *
  * The output value is a string with the format `yyyy-mm-dd`.
  */
-export function date(attributes?: {
-  required?: false;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-${number}-${number}` | null> & {
+export function date(
+  attributes?: {
+    required?: false;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max">,
+): FormInput<`${number}-${number}-${number}` | null> & {
   asNumber(): FormInput<number | null>;
   asDate(): FormInput<Date | null>;
 };
-export function date(attributes: {
-  required: true;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-${number}-${number}`> & {
+export function date(
+  attributes: {
+    required: true;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max">,
+): FormInput<`${number}-${number}-${number}`> & {
   asNumber(): FormInput<number>;
   asDate(): FormInput<Date>;
 };
 export function date(
   attributes: { required?: boolean; min?: string; max?: string } = {},
+  failures: Failures<"type" | "required" | "invalid" | "min" | "max"> = {},
 ): FormInput<`${number}-${number}-${number}` | null> & {
   asNumber(): FormInput<number | null>;
   asDate(): FormInput<Date | null>;
@@ -38,12 +52,15 @@ export function date(
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (value === "") return attributes.required ? failures.required() : succeed(null);
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return failures.invalid();
-      if (Number.isNaN(Date.parse(value))) return failures.invalid();
-      if (attributes.min && value < attributes.min) return failures.min(attributes.min);
-      if (attributes.max && value > attributes.max) return failures.max(attributes.max);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (value === "")
+        return attributes.required ? failParse("required", failures) : succeed(null);
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return failParse("invalid", failures);
+      if (Number.isNaN(Date.parse(value))) return failParse("invalid", failures);
+      if (attributes.min && value < attributes.min)
+        return failParse("min", failures, { min: attributes.min });
+      if (attributes.max && value > attributes.max)
+        return failParse("max", failures, { max: attributes.max });
       return succeed(value as `${number}-${number}-${number}`);
     },
     /**

--- a/src/validators/datetimeLocal.test.ts
+++ b/src/validators/datetimeLocal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { datetimeLocal } from "./datetimeLocal.ts";
 
 describe("date()", async () => {
@@ -45,24 +45,24 @@ describe("date()", async () => {
     data.append("nad", "2024-13-01T22:45");
     data.append("ok", "2024-09-30T22:45");
 
-    assert.deepEqualTyped(datetimeLocal()[safeParse](data, "missing"), failures.type());
+    assert.deepEqualTyped(datetimeLocal()[safeParse](data, "missing"), failParse("type", {}));
     assert.deepEqualTyped(
       datetimeLocal({ required: true })[safeParse](data, "empty"),
-      failures.required(),
+      failParse("required", {}),
     );
-    assert.deepEqualTyped(datetimeLocal()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(datetimeLocal()[safeParse](data, "nad"), failures.invalid());
+    assert.deepEqualTyped(datetimeLocal()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(datetimeLocal()[safeParse](data, "nad"), failParse("invalid", {}));
     assert.deepEqualTyped(
       datetimeLocal({
         min: "2024-09-30T22:46",
       })[safeParse](data, "ok"),
-      failures.min("2024-09-30T22:46"),
+      failParse("min", {}, { min: "2024-09-30T22:46" }),
     );
     assert.deepEqualTyped(
       datetimeLocal({
         max: "2024-09-30T22:44",
       })[safeParse](data, "ok"),
-      failures.max("2024-09-30T22:44"),
+      failParse("max", {}, { max: "2024-09-30T22:44" }),
     );
   });
 });

--- a/src/validators/datetimeLocal.ts
+++ b/src/validators/datetimeLocal.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="datetime-local">` form input validator.
@@ -11,24 +18,31 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  *
  * The output value is a string with the format `yyyy-mm-ddThh:mm`.
  */
-export function datetimeLocal(attributes?: {
-  required?: false;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-${number}-${number}T${number}:${number}` | null> & {
+export function datetimeLocal(
+  attributes?: {
+    required?: false;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"required" | "min" | "max" | "invalid" | "type">,
+): FormInput<`${number}-${number}-${number}T${number}:${number}` | null> & {
   asNumber(): FormInput<number | null>;
   asDate(): FormInput<Date | null>;
 };
-export function datetimeLocal(attributes: {
-  required: true;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-${number}-${number}T${number}:${number}`> & {
+export function datetimeLocal(
+  attributes: {
+    required: true;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"required" | "min" | "max" | "invalid" | "type">,
+): FormInput<`${number}-${number}-${number}T${number}:${number}`> & {
   asNumber(): FormInput<number>;
   asDate(): FormInput<Date>;
 };
 export function datetimeLocal(
   attributes: { required?: boolean; min?: string; max?: string } = {},
+  failures: Failures<"required" | "min" | "max" | "invalid" | "type"> = {},
 ): FormInput<`${number}-${number}-${number}T${number}:${number}` | null> & {
   asNumber(): FormInput<number | null>;
   asDate(): FormInput<Date | null>;
@@ -38,12 +52,15 @@ export function datetimeLocal(
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (value === "") return attributes.required ? failures.required() : succeed(null);
-      if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) return failures.invalid();
-      if (Number.isNaN(Date.parse(value))) return failures.invalid();
-      if (attributes.min && value < attributes.min) return failures.min(attributes.min);
-      if (attributes.max && value > attributes.max) return failures.max(attributes.max);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (value === "")
+        return attributes.required ? failParse("required", failures) : succeed(null);
+      if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) return failParse("invalid", failures);
+      if (Number.isNaN(Date.parse(value))) return failParse("invalid", failures);
+      if (attributes.min && value < attributes.min)
+        return failParse("min", failures, { min: attributes.min });
+      if (attributes.max && value > attributes.max)
+        return failParse("max", failures, { max: attributes.max });
       return succeed(value as `${number}-${number}-${number}T${number}:${number}`);
     },
     /**

--- a/src/validators/email.test.ts
+++ b/src/validators/email.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { email } from "./email.ts";
 
 describe("email()", async () => {
@@ -42,23 +42,35 @@ describe("email()", async () => {
     data.append("empty", "");
     data.append("ok", "gautier@example.com");
 
-    assert.deepEqualTyped(email()[safeParse](data, "missing"), failures.type());
-    assert.deepEqualTyped(email({ required: true })[safeParse](data, "empty"), failures.required());
-    assert.deepEqualTyped(email()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(email({ multiple: true })[safeParse](data, "input"), failures.invalid());
+    assert.deepEqualTyped(email()[safeParse](data, "missing"), failParse("type", {}));
+    assert.deepEqualTyped(
+      email({ required: true })[safeParse](data, "empty"),
+      failParse("required", {}),
+    );
+    assert.deepEqualTyped(email()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(
+      email({ multiple: true })[safeParse](data, "input"),
+      failParse("invalid", {}),
+    );
     assert.deepEqualTyped(
       email({ multiple: true })[safeParse](data, "multiple"),
-      failures.invalid(),
+      failParse("invalid", {}),
     );
-    assert.deepEqualTyped(email({ minlength: 20 })[safeParse](data, "ok"), failures.minlength(20));
-    assert.deepEqualTyped(email({ maxlength: 18 })[safeParse](data, "ok"), failures.maxlength(18));
+    assert.deepEqualTyped(
+      email({ minlength: 20 })[safeParse](data, "ok"),
+      failParse("minlength", {}, { minlength: 20 }),
+    );
+    assert.deepEqualTyped(
+      email({ maxlength: 18 })[safeParse](data, "ok"),
+      failParse("maxlength", {}, { maxlength: 18 }),
+    );
     assert.deepEqualTyped(
       email({ pattern: /^.+@example\.net$/u })[safeParse](data, "ok"),
-      failures.pattern(/^.+@example\.net$/u),
+      failParse("pattern", {}, { pattern: /^.+@example\.net$/u }),
     );
     assert.deepEqualTyped(
       email({ multiple: true, pattern: /^.+@example\.net$/u })[safeParse](data, "ok"),
-      failures.pattern(/^.+@example\.net$/u),
+      failParse("pattern", {}, { pattern: /^.+@example\.net$/u }),
     );
   });
 });

--- a/src/validators/file.test.ts
+++ b/src/validators/file.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { file } from "./file.ts";
 
 describe("file()", async () => {
@@ -23,31 +23,34 @@ describe("file()", async () => {
     data.append("input", "invalid");
     data.append("ok", f);
 
-    assert.deepEqualTyped(file()[safeParse](data, "input"), failures.type());
+    assert.deepEqualTyped(file()[safeParse](data, "input"), failParse("type", {}));
     assert.deepEqualTyped(
       file({ required: true })[safeParse](data, "missing"),
-      failures.required(),
+      failParse("required", {}),
     );
-    assert.deepEqualTyped(file({ multiple: true })[safeParse](data, "input"), failures.type());
+    assert.deepEqualTyped(
+      file({ multiple: true })[safeParse](data, "input"),
+      failParse("type", {}),
+    );
     assert.deepEqualTyped(
       file({ multiple: true, required: true })[safeParse](data, "missing"),
-      failures.required(),
+      failParse("required", {}),
     );
     assert.deepEqualTyped(
       file({ accept: [".jpg"] })[safeParse](data, "ok"),
-      failures.accept([".jpg"]),
+      failParse("accept", {}),
     );
     assert.deepEqualTyped(
       file({ accept: ["image/*"] })[safeParse](data, "ok"),
-      failures.accept(["image/*"]),
+      failParse("accept", {}),
     );
     assert.deepEqualTyped(
       file({ accept: ["image/jpeg"] })[safeParse](data, "ok"),
-      failures.accept(["image/jpeg"]),
+      failParse("accept", {}),
     );
     assert.deepEqualTyped(
       file({ multiple: true, accept: [".jpg"] })[safeParse](data, "ok"),
-      failures.accept([".jpg"]),
+      failParse("accept", {}),
     );
   });
 });

--- a/src/validators/file.ts
+++ b/src/validators/file.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="file">` form input validator.
@@ -10,27 +17,37 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  * - `accept` - The accepted file types, as an array of MIME types (`image/png`),
  *   MIME wildcards (`image/*`), or file extensions (`.png`).
  */
-export function file(attributes?: {
-  multiple?: false;
-  required?: false;
-  accept?: string[];
-}): FormInput<File | null>;
-export function file(attributes: {
-  multiple: true;
-  required?: boolean;
-  accept?: string[];
-}): FormInput<File[]>;
-export function file(attributes: {
-  multiple?: false;
-  required: true;
-  accept?: string[];
-}): FormInput<File>;
+export function file(
+  attributes?: {
+    multiple?: false;
+    required?: false;
+    accept?: string[];
+  },
+  failures?: Failures<"type" | "required" | "accept">,
+): FormInput<File | null>;
+export function file(
+  attributes: {
+    multiple: true;
+    required?: boolean;
+    accept?: string[];
+  },
+  failures?: Failures<"type" | "required" | "accept">,
+): FormInput<File[]>;
+export function file(
+  attributes: {
+    multiple?: false;
+    required: true;
+    accept?: string[];
+  },
+  failures?: Failures<"type" | "required" | "accept">,
+): FormInput<File>;
 export function file(
   attributes: {
     multiple?: boolean;
     required?: boolean;
     accept?: string[];
   } = {},
+  failures: Failures = {},
 ): FormInput<File | File[] | null> {
   const accept = (file: File) => {
     if (!attributes.accept) return true;
@@ -47,19 +64,20 @@ export function file(
     [safeParse]: attributes.multiple
       ? (data, name) => {
           const values = data.getAll(name);
-          if (values.length === 0) return attributes.required ? failures.required() : succeed([]);
+          if (values.length === 0)
+            return attributes.required ? failParse("required", failures) : succeed([]);
           for (const value of values) {
-            if (!(value instanceof File)) return failures.type();
-            if (!accept(value)) return failures.accept(attributes.accept!);
+            if (!(value instanceof File)) return failParse("type", failures);
+            if (!accept(value)) return failParse("accept", failures);
           }
           return succeed(values as File[]);
         }
       : (data, name) => {
           const value = data.get(name);
-          if (value !== null && !(value instanceof File)) return failures.type();
+          if (value !== null && !(value instanceof File)) return failParse("type", failures);
           if (value === null || (value.size === 0 && value.name === ""))
-            return attributes.required ? failures.required() : succeed(null);
-          if (!accept(value)) return failures.accept(attributes.accept!);
+            return attributes.required ? failParse("required", failures) : succeed(null);
+          if (!accept(value)) return failParse("accept", failures);
           return succeed(value);
         },
   };

--- a/src/validators/hidden.test.ts
+++ b/src/validators/hidden.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { hidden } from "./hidden.ts";
 
 describe("hidden()", async () => {
@@ -12,6 +12,6 @@ describe("hidden()", async () => {
   });
 
   it("should refuse invalid inputs", () => {
-    assert.deepEqualTyped(hidden()[safeParse](new FormData(), "missing"), failures.type());
+    assert.deepEqualTyped(hidden()[safeParse](new FormData(), "missing"), failParse("type", {}));
   });
 });

--- a/src/validators/hidden.ts
+++ b/src/validators/hidden.ts
@@ -1,17 +1,24 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="hidden">` form input validator.
  *
  * Not very useful, but included for completeness.
  */
-export function hidden(): FormInput<string> {
+export function hidden(failures: Failures<"type"> = {}): FormInput<string> {
   return {
     ...methods,
     attributes: {},
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
+      if (typeof value !== "string") return failParse("type", failures);
       return succeed(value);
     },
   };

--- a/src/validators/image.test.ts
+++ b/src/validators/image.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { image } from "./image.ts";
 
 describe("image()", async () => {
@@ -20,7 +20,7 @@ describe("image()", async () => {
     data.append("input.x", "invalid");
     data.append("input.y", "invalid");
 
-    assert.deepEqualTyped(image()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(image()[safeParse](data, "missing"), failures.type());
+    assert.deepEqualTyped(image()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(image()[safeParse](data, "missing"), failParse("type", {}));
   });
 });

--- a/src/validators/image.ts
+++ b/src/validators/image.ts
@@ -1,19 +1,28 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /** `<input type="image">` form input validator. */
-export function image(): FormInput<{ x: number; y: number }> {
+export function image(
+  failures: Failures<"type" | "invalid"> = {},
+): FormInput<{ x: number; y: number }> {
   return {
     ...methods,
     attributes: {},
     [safeParse]: (data, name) => {
       const x = name === "" ? data.get("x") : data.get(`${name}.x`);
       const y = name === "" ? data.get("y") : data.get(`${name}.y`);
-      if (typeof x !== "string" || typeof y !== "string") return failures.type();
+      if (typeof x !== "string" || typeof y !== "string") return failParse("type", failures);
       const coords = {
         x: Number(x),
         y: Number(y),
       };
-      if (Number.isNaN(coords.x) || Number.isNaN(coords.y)) return failures.invalid();
+      if (Number.isNaN(coords.x) || Number.isNaN(coords.y)) return failParse("invalid", failures);
       return succeed(coords);
     },
   };

--- a/src/validators/month.test.ts
+++ b/src/validators/month.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { month } from "./month.ts";
 
 describe("month()", async () => {
@@ -37,17 +37,20 @@ describe("month()", async () => {
     data.append("nad", "2024-13");
     data.append("ok", "2024-09");
 
-    assert.deepEqualTyped(month()[safeParse](data, "missing"), failures.type());
-    assert.deepEqualTyped(month({ required: true })[safeParse](data, "empty"), failures.required());
-    assert.deepEqualTyped(month()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(month()[safeParse](data, "nad"), failures.invalid());
+    assert.deepEqualTyped(month()[safeParse](data, "missing"), failParse("type", {}));
+    assert.deepEqualTyped(
+      month({ required: true })[safeParse](data, "empty"),
+      failParse("required", {}),
+    );
+    assert.deepEqualTyped(month()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(month()[safeParse](data, "nad"), failParse("invalid", {}));
     assert.deepEqualTyped(
       month({ min: "2024-10" })[safeParse](data, "ok"),
-      failures.min("2024-10"),
+      failParse("min", {}, { min: "2024-10" }),
     );
     assert.deepEqualTyped(
       month({ max: "2024-08" })[safeParse](data, "ok"),
-      failures.max("2024-08"),
+      failParse("max", {}, { max: "2024-08" }),
     );
   });
 });

--- a/src/validators/month.ts
+++ b/src/validators/month.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  failParse,
+  type Failures,
+  type FormInput,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="month">` form input validator.
@@ -11,24 +18,31 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  *
  * The output value is a string with the format `yyyy-mm`.
  */
-export function month(attributes?: {
-  required?: false;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-${number}` | null> & {
+export function month(
+  attributes?: {
+    required?: false;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max">,
+): FormInput<`${number}-${number}` | null> & {
   asNumber(): FormInput<number | null>;
   asDate(): FormInput<Date | null>;
 };
-export function month(attributes: {
-  required: true;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-${number}`> & {
+export function month(
+  attributes: {
+    required: true;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max">,
+): FormInput<`${number}-${number}`> & {
   asNumber(): FormInput<number>;
   asDate(): FormInput<Date>;
 };
 export function month(
   attributes: { required?: boolean; min?: string; max?: string } = {},
+  failures: Failures<"type" | "required" | "invalid" | "min" | "max"> = {},
 ): FormInput<`${number}-${number}` | null> & {
   asNumber(): FormInput<number | null>;
   asDate(): FormInput<Date | null>;
@@ -38,11 +52,14 @@ export function month(
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (value === "") return attributes.required ? failures.required() : succeed(null);
-      if (!/^\d{4}-(0\d|1[12])$/.test(value)) return failures.invalid();
-      if (attributes.min && value < attributes.min) return failures.min(attributes.min);
-      if (attributes.max && value > attributes.max) return failures.max(attributes.max);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (value === "")
+        return attributes.required ? failParse("required", failures) : succeed(null);
+      if (!/^\d{4}-(0\d|1[12])$/.test(value)) return failParse("invalid", failures);
+      if (attributes.min && value < attributes.min)
+        return failParse("min", failures, { min: attributes.min });
+      if (attributes.max && value > attributes.max)
+        return failParse("max", failures, { max: attributes.max });
       return succeed(value as `${number}-${number}`);
     },
     /**

--- a/src/validators/multi.test.ts
+++ b/src/validators/multi.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { fail, failParse, safeParse, succeed } from "../definitions.ts";
 import { multi } from "./multi.ts";
 
 describe("multi()", async () => {
@@ -44,9 +44,15 @@ describe("multi()", async () => {
     data.append("input", "");
     data.append("file", new File(["hmm"], "file.txt"));
 
-    assert.deepEqualTyped(multi()[safeParse](data, "file"), failures.type());
-    assert.deepEqualTyped(multi({ min: 4 })[safeParse](data, "input"), failures.minlength(4));
-    assert.deepEqualTyped(multi({ max: 2 })[safeParse](data, "input"), failures.maxlength(2));
+    assert.deepEqualTyped(multi()[safeParse](data, "file"), failParse("type", {}));
+    assert.deepEqualTyped(
+      multi({ min: 4 })[safeParse](data, "input"),
+      failParse("minlength", {}, { minlength: 4 }),
+    );
+    assert.deepEqualTyped(
+      multi({ max: 2 })[safeParse](data, "input"),
+      failParse("maxlength", {}, { maxlength: 2 }),
+    );
     assert.deepEqualTyped(
       multi()
         .map(
@@ -56,7 +62,7 @@ describe("multi()", async () => {
           (error) => (error as Error).message,
         )
         [safeParse](data, "input"),
-      failures.transform("Custom error"),
+      fail({ code: "transform" as const, message: "Custom error" }),
     );
   });
 });

--- a/src/validators/multi.ts
+++ b/src/validators/multi.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * Validator for multiple inputs with the same name.
@@ -8,12 +15,15 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  * - `min` - Minimum number of values, defaults to 0.
  * - `max` - Maximum number of values, defaults to `Infinity`.
  */
-export function multi(attributes?: {
-  /** Minimum number of values. */
-  min?: number;
-  /** Maximum number of values. */
-  max?: number;
-}): FormInput<string[]> & {
+export function multi(
+  attributes?: {
+    /** Minimum number of values. */
+    min?: number;
+    /** Maximum number of values. */
+    max?: number;
+  },
+  failures: Failures<"type" | "minlength" | "maxlength"> = {},
+): FormInput<string[]> & {
   /** Runs `fn` function on each element. If `fn` throws, the form is rejected. */
   map<T>(
     fn: (value: string, index: number, array: string[]) => T,
@@ -26,13 +36,13 @@ export function multi(attributes?: {
     [safeParse]: (data, name) => {
       const values: string[] = [];
       for (const value of data.getAll(name)) {
-        if (typeof value !== "string") return failures.type();
+        if (typeof value !== "string") return failParse("type", failures);
         values.push(value);
       }
       if (attributes?.min !== undefined && values.length < attributes.min)
-        return failures.minlength(attributes.min);
+        return failParse("minlength", failures, { minlength: attributes.min });
       if (attributes?.max !== undefined && values.length > attributes.max)
-        return failures.maxlength(attributes.max);
+        return failParse("maxlength", failures, { maxlength: attributes.max });
       return succeed(values);
     },
     map(fn, catcher) {

--- a/src/validators/number.test.ts
+++ b/src/validators/number.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { number } from "./number.ts";
 
 describe("number()", async () => {
@@ -29,14 +29,23 @@ describe("number()", async () => {
     data.append("empty", "");
     data.append("ok", "123");
 
-    assert.deepEqualTyped(number()[safeParse](data, "missing"), failures.type());
+    assert.deepEqualTyped(number()[safeParse](data, "missing"), failParse("type", {}));
     assert.deepEqualTyped(
       number({ required: true })[safeParse](data, "empty"),
-      failures.required(),
+      failParse("required", {}),
     );
-    assert.deepEqualTyped(number()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(number({ min: 124 })[safeParse](data, "ok"), failures.min(124));
-    assert.deepEqualTyped(number({ max: 122 })[safeParse](data, "ok"), failures.max(122));
-    assert.deepEqualTyped(number({ step: 2 })[safeParse](data, "ok"), failures.step(2));
+    assert.deepEqualTyped(number()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(
+      number({ min: 124 })[safeParse](data, "ok"),
+      failParse("min", {}, { min: 124 }),
+    );
+    assert.deepEqualTyped(
+      number({ max: 122 })[safeParse](data, "ok"),
+      failParse("max", {}, { max: 122 }),
+    );
+    assert.deepEqualTyped(
+      number({ step: 2 })[safeParse](data, "ok"),
+      failParse("step", {}, { step: 2 }),
+    );
   });
 });

--- a/src/validators/number.ts
+++ b/src/validators/number.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="number">` form input validator.
@@ -9,27 +16,33 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  * - `min` - Minimum value.
  * - `max` - Maximum value.
  */
-export function number(attributes?: {
-  required?: false;
-  min?: number;
-  max?: number;
-  /**
-   * Accepted granularity of the value. Default is 1 (integer), set to 0 to
-   * allow any number.
-   *
-   * The value must be a multiple of the step attribute, i.e. it could be
-   * written as: `value = (min ?? 0) + k * step` with `k` an integer.
-   *
-   * @default 1 (only integers are accepted)
-   */
-  step?: number;
-}): FormInput<number | null>;
-export function number(attributes: {
-  required: true;
-  min?: number;
-  max?: number;
-  step?: number;
-}): FormInput<number>;
+export function number(
+  attributes?: {
+    required?: false;
+    min?: number;
+    max?: number;
+    /**
+     * Accepted granularity of the value. Default is 1 (integer), set to 0 to
+     * allow any number.
+     *
+     * The value must be a multiple of the step attribute, i.e. it could be
+     * written as: `value = (min ?? 0) + k * step` with `k` an integer.
+     *
+     * @default 1 (only integers are accepted)
+     */
+    step?: number;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max" | "step">,
+): FormInput<number | null>;
+export function number(
+  attributes: {
+    required: true;
+    min?: number;
+    max?: number;
+    step?: number;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max" | "step">,
+): FormInput<number>;
 export function number(
   attributes: {
     required?: boolean;
@@ -37,25 +50,28 @@ export function number(
     max?: number;
     step?: number;
   } = {},
+  failures: Failures<"type" | "required" | "invalid" | "min" | "max" | "step"> = {},
 ): FormInput<number | null> {
   return {
     ...methods,
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (value === "") return attributes.required ? failures.required() : succeed(null);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (value === "")
+        return attributes.required ? failParse("required", failures) : succeed(null);
 
       const number = Number(value);
-      if (Number.isNaN(number)) return failures.invalid();
+      if (Number.isNaN(number)) return failParse("invalid", failures);
 
       const step = attributes.step ?? 1;
-      if (step > 0 && (number - (attributes.min ?? 0)) % step !== 0) return failures.step(step);
+      if (step > 0 && (number - (attributes.min ?? 0)) % step !== 0)
+        return failParse("step", failures, { step: step });
 
       if (attributes.min !== undefined && number < attributes.min)
-        return failures.min(attributes.min);
+        return failParse("min", failures, { min: attributes.min });
       if (attributes.max !== undefined && number > attributes.max)
-        return failures.max(attributes.max);
+        return failParse("max", failures, { max: attributes.max });
       return succeed(number);
     },
   };

--- a/src/validators/radio.test.ts
+++ b/src/validators/radio.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { radio } from "./radio.ts";
 
 describe("radio()", async () => {
@@ -21,11 +21,11 @@ describe("radio()", async () => {
     data.append("input", "invalid");
     data.append("file", new File([], "file.txt"));
 
-    assert.deepEqualTyped(radio([])[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(radio([])[safeParse](data, "file"), failures.type());
+    assert.deepEqualTyped(radio([])[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(radio([])[safeParse](data, "file"), failParse("type", {}));
     assert.deepEqualTyped(
       radio([], { required: true })[safeParse](data, "missing"),
-      failures.required(),
+      failParse("required", {}),
     );
   });
 });

--- a/src/validators/radio.ts
+++ b/src/validators/radio.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="radio">` form input validator.
@@ -10,20 +17,27 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
 export function radio<T extends string>(
   values: T[],
   attributes?: { required?: false },
+  failures?: Failures<"required" | "invalid" | "type">,
 ): FormInput<T | null>;
-export function radio<T extends string>(values: T[], attributes: { required: true }): FormInput<T>;
+export function radio<T extends string>(
+  values: T[],
+  attributes: { required: true },
+  failures?: Failures<"required" | "invalid" | "type">,
+): FormInput<T>;
 export function radio<T extends string>(
   values: T[],
   attributes: { required?: boolean } = {},
+  failures: Failures<"required" | "invalid" | "type"> = {},
 ): FormInput<T | null> {
   return {
     ...methods,
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (value === null) return attributes.required ? failures.required() : succeed(null);
-      if (typeof value !== "string") return failures.type();
-      if (!(values as string[]).includes(value)) return failures.invalid();
+      if (value === null)
+        return attributes.required ? failParse("required", failures) : succeed(null);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (!(values as string[]).includes(value)) return failParse("invalid", failures);
       return succeed(value as T);
     },
   };

--- a/src/validators/range.test.ts
+++ b/src/validators/range.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { range } from "./range.ts";
 
 describe("range()", async () => {
@@ -17,8 +17,8 @@ describe("range()", async () => {
     data.append("high", "101");
     data.append("float", "1.5");
 
-    assert.deepEqualTyped(range()[safeParse](data, "low"), failures.min(0));
-    assert.deepEqualTyped(range()[safeParse](data, "high"), failures.max(100));
-    assert.deepEqualTyped(range()[safeParse](data, "float"), failures.step(1));
+    assert.deepEqualTyped(range()[safeParse](data, "low"), failParse("min", {}, { min: 0 }));
+    assert.deepEqualTyped(range()[safeParse](data, "high"), failParse("max", {}, { max: 100 }));
+    assert.deepEqualTyped(range()[safeParse](data, "float"), failParse("step", {}, { step: 1 }));
   });
 });

--- a/src/validators/range.ts
+++ b/src/validators/range.ts
@@ -1,4 +1,4 @@
-import type { FormInput } from "../definitions.ts";
+import type { Failures, FormInput } from "../definitions.ts";
 import { number } from "./number.ts";
 
 /**
@@ -12,14 +12,18 @@ import { number } from "./number.ts";
  */
 export function range(
   attributes: { min?: number; max?: number; step?: number } = {},
+  failures: Failures<"type" | "required" | "invalid" | "min" | "max" | "step"> = {},
 ): FormInput<number> {
   return {
-    ...number({
-      required: true,
-      min: attributes.min ?? 0,
-      max: attributes.max ?? 100,
-      step: attributes.step ?? 1,
-    }),
+    ...number(
+      {
+        required: true,
+        min: attributes.min ?? 0,
+        max: attributes.max ?? 100,
+        step: attributes.step ?? 1,
+      },
+      failures,
+    ),
     attributes,
   };
 }

--- a/src/validators/select.test.ts
+++ b/src/validators/select.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { select } from "./select.ts";
 
 describe("select()", async () => {
@@ -36,23 +36,26 @@ describe("select()", async () => {
     data.append("empty", "");
     data.append("file", new File([], "file.txt"));
 
-    assert.deepEqualTyped(select(["option"])[safeParse](data, "input"), failures.invalid());
+    assert.deepEqualTyped(select(["option"])[safeParse](data, "input"), failParse("invalid", {}));
     assert.deepEqualTyped(
       select(["option"], { multiple: true })[safeParse](data, "input"),
-      failures.invalid(),
+      failParse("invalid", {}),
     );
     assert.deepEqualTyped(
       select([], { required: true })[safeParse](data, "missing"),
-      failures.type(),
+      failParse("type", {}),
     );
     assert.deepEqualTyped(
       select([], { multiple: true, required: true })[safeParse](data, "missing"),
-      failures.required(),
+      failParse("required", {}),
     );
     assert.deepEqualTyped(
       select([], { required: true })[safeParse](data, "empty"),
-      failures.required(),
+      failParse("required", {}),
     );
-    assert.deepEqualTyped(select([], { multiple: true })[safeParse](data, "file"), failures.type());
+    assert.deepEqualTyped(
+      select([], { multiple: true })[safeParse](data, "file"),
+      failParse("type", {}),
+    );
   });
 });

--- a/src/validators/text.test.ts
+++ b/src/validators/text.test.ts
@@ -33,7 +33,10 @@ describe("text()", async () => {
     data.append("empty", "");
     data.append("ok", "hello world!");
 
-    assert.deepEqualTyped(text()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(
+      text({}, { invalid: "Nope, not valid" })[safeParse](data, "input"),
+      failParse("invalid", { invalid: "Nope, not valid" }),
+    );
     assert.deepEqualTyped(text()[safeParse](data, "missing"), failParse("type", {}));
     assert.deepEqualTyped(
       text({ required: true })[safeParse](data, "empty"),
@@ -44,8 +47,10 @@ describe("text()", async () => {
       failParse("minlength", {}, { minlength: 13 }),
     );
     assert.deepEqualTyped(
-      text({ maxlength: 11 })[safeParse](data, "ok"),
-      failParse("maxlength", {}, { maxlength: 11 }),
+      text({ maxlength: 11 }, { maxlength: ({ maxlength }) => `${maxlength} chars plz` })[
+        safeParse
+      ](data, "ok"),
+      failParse("maxlength", { maxlength: "11 chars plz" }, { maxlength: 11 }),
     );
     assert.deepEqualTyped(
       text({ pattern: /^\w+ \w+\?$/u })[safeParse](data, "ok"),

--- a/src/validators/text.test.ts
+++ b/src/validators/text.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { text } from "./text.ts";
 
 describe("text()", async () => {
@@ -33,14 +33,23 @@ describe("text()", async () => {
     data.append("empty", "");
     data.append("ok", "hello world!");
 
-    assert.deepEqualTyped(text()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(text()[safeParse](data, "missing"), failures.type());
-    assert.deepEqualTyped(text({ required: true })[safeParse](data, "empty"), failures.required());
-    assert.deepEqualTyped(text({ minlength: 13 })[safeParse](data, "ok"), failures.minlength(13));
-    assert.deepEqualTyped(text({ maxlength: 11 })[safeParse](data, "ok"), failures.maxlength(11));
+    assert.deepEqualTyped(text()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(text()[safeParse](data, "missing"), failParse("type", {}));
+    assert.deepEqualTyped(
+      text({ required: true })[safeParse](data, "empty"),
+      failParse("required", {}),
+    );
+    assert.deepEqualTyped(
+      text({ minlength: 13 })[safeParse](data, "ok"),
+      failParse("minlength", {}, { minlength: 13 }),
+    );
+    assert.deepEqualTyped(
+      text({ maxlength: 11 })[safeParse](data, "ok"),
+      failParse("maxlength", {}, { maxlength: 11 }),
+    );
     assert.deepEqualTyped(
       text({ pattern: /^\w+ \w+\?$/u })[safeParse](data, "ok"),
-      failures.pattern(/^\w+ \w+\?$/u),
+      failParse("pattern", {}, { pattern: /^\w+ \w+\?$/u }),
     );
   });
 });

--- a/src/validators/textarea.test.ts
+++ b/src/validators/textarea.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { textarea } from "./textarea.ts";
 
 describe("textarea()", async () => {
@@ -32,18 +32,18 @@ describe("textarea()", async () => {
     data.append("empty", "");
     data.append("ok", "hello world!");
 
-    assert.deepEqualTyped(textarea()[safeParse](data, "missing"), failures.type());
+    assert.deepEqualTyped(textarea()[safeParse](data, "missing"), failParse("type", {}));
     assert.deepEqualTyped(
       textarea({ required: true })[safeParse](data, "empty"),
-      failures.required(),
+      failParse("required", {}),
     );
     assert.deepEqualTyped(
       textarea({ minlength: 13 })[safeParse](data, "ok"),
-      failures.minlength(13),
+      failParse("minlength", {}, { minlength: 13 }),
     );
     assert.deepEqualTyped(
       textarea({ maxlength: 11 })[safeParse](data, "ok"),
-      failures.maxlength(11),
+      failParse("maxlength", {}, { maxlength: 11 }),
     );
   });
 });

--- a/src/validators/textarea.ts
+++ b/src/validators/textarea.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<textarea>` form input validator.
@@ -9,34 +16,42 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  * - `maxlength` - Maximum length of the input.
  * - `minlength` - Minimum length of the input.
  */
-export function textarea(attributes?: {
-  required?: false;
-  maxlength?: number;
-  minlength?: number;
-}): FormInput<string | null> & { trim: () => FormInput<string> };
-export function textarea(attributes: {
-  required: true;
-  maxlength?: number;
-  minlength?: number;
-}): FormInput<string> & { trim: () => FormInput<string> };
+export function textarea(
+  attributes?: {
+    required?: false;
+    maxlength?: number;
+    minlength?: number;
+  },
+  failures?: Failures<"type" | "maxlength" | "minlength" | "required">,
+): FormInput<string | null> & { trim: () => FormInput<string> };
+export function textarea(
+  attributes: {
+    required: true;
+    maxlength?: number;
+    minlength?: number;
+  },
+  failures?: Failures<"type" | "maxlength" | "minlength" | "required">,
+): FormInput<string> & { trim: () => FormInput<string> };
 export function textarea(
   attributes: {
     required?: boolean;
     maxlength?: number;
     minlength?: number;
   } = {},
+  failures: Failures<"type" | "maxlength" | "minlength" | "required"> = {},
 ): FormInput<string | null> & { trim(): FormInput<string> } {
   return {
     ...methods,
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (value === "") return attributes.required ? failures.required() : succeed(null);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (value === "")
+        return attributes.required ? failParse("required", failures) : succeed(null);
       if (attributes.maxlength && value.length > attributes.maxlength)
-        return failures.maxlength(attributes.maxlength);
+        return failParse("maxlength", failures, { maxlength: attributes.maxlength });
       if (attributes.minlength && value.length < attributes.minlength)
-        return failures.minlength(attributes.minlength);
+        return failParse("minlength", failures, { minlength: attributes.minlength });
       return succeed(value);
     },
     /** Removes the leading and trailing white space from the value. */

--- a/src/validators/time.test.ts
+++ b/src/validators/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { time } from "./time.ts";
 
 describe("time()", async () => {
@@ -26,11 +26,20 @@ describe("time()", async () => {
     data.append("nad", "15:60");
     data.append("ok", "15:43");
 
-    assert.deepEqualTyped(time()[safeParse](data, "missing"), failures.type());
-    assert.deepEqualTyped(time({ required: true })[safeParse](data, "empty"), failures.required());
-    assert.deepEqualTyped(time()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(time()[safeParse](data, "nad"), failures.invalid());
-    assert.deepEqualTyped(time({ min: "15:44" })[safeParse](data, "ok"), failures.min("15:44"));
-    assert.deepEqualTyped(time({ max: "15:42" })[safeParse](data, "ok"), failures.max("15:42"));
+    assert.deepEqualTyped(time()[safeParse](data, "missing"), failParse("type", {}));
+    assert.deepEqualTyped(
+      time({ required: true })[safeParse](data, "empty"),
+      failParse("required", {}),
+    );
+    assert.deepEqualTyped(time()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(time()[safeParse](data, "nad"), failParse("invalid", {}));
+    assert.deepEqualTyped(
+      time({ min: "15:44" })[safeParse](data, "ok"),
+      failParse("min", {}, { min: "15:44" }),
+    );
+    assert.deepEqualTyped(
+      time({ max: "15:42" })[safeParse](data, "ok"),
+      failParse("max", {}, { max: "15:42" }),
+    );
   });
 });

--- a/src/validators/time.ts
+++ b/src/validators/time.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="time">` form input validator.
@@ -11,22 +18,29 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  *
  * The output value is a string with the format `yyyy-mm-dd`.
  */
-export function time(attributes?: {
-  required?: false;
-  min?: string;
-  max?: string;
-}): FormInput<string | null> & {
+export function time(
+  attributes?: {
+    required?: false;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max">,
+): FormInput<string | null> & {
   asSeconds(): FormInput<number | null>;
 };
-export function time(attributes: {
-  required: true;
-  min?: string;
-  max?: string;
-}): FormInput<string> & {
+export function time(
+  attributes: {
+    required: true;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"type" | "required" | "invalid" | "min" | "max">,
+): FormInput<string> & {
   asSeconds(): FormInput<number>;
 };
 export function time(
   attributes: { required?: boolean; min?: string; max?: string } = {},
+  failures: Failures<"type" | "required" | "invalid" | "min" | "max"> = {},
 ): FormInput<string | null> & {
   asSeconds(): FormInput<number | null>;
 } {
@@ -35,11 +49,14 @@ export function time(
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (value === "") return attributes.required ? failures.required() : succeed(null);
-      if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) return failures.invalid();
-      if (attributes.min && value < attributes.min) return failures.min(attributes.min);
-      if (attributes.max && value > attributes.max) return failures.max(attributes.max);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (value === "")
+        return attributes.required ? failParse("required", failures) : succeed(null);
+      if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) return failParse("invalid", failures);
+      if (attributes.min && value < attributes.min)
+        return failParse("min", failures, { min: attributes.min });
+      if (attributes.max && value > attributes.max)
+        return failParse("max", failures, { max: attributes.max });
       return succeed(value);
     },
     /** Returns the time as a number of seconds. */

--- a/src/validators/url.test.ts
+++ b/src/validators/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { url } from "./url.ts";
 
 describe("url()", async () => {
@@ -23,8 +23,11 @@ describe("url()", async () => {
     data.append("input", "invalid");
     data.append("empty", "");
 
-    assert.deepEqualTyped(url()[safeParse](data, "missing"), failures.type());
-    assert.deepEqualTyped(url({ required: true })[safeParse](data, "empty"), failures.required());
-    assert.deepEqualTyped(url()[safeParse](data, "input"), failures.invalid());
+    assert.deepEqualTyped(url()[safeParse](data, "missing"), failParse("type", {}));
+    assert.deepEqualTyped(
+      url({ required: true })[safeParse](data, "empty"),
+      failParse("required", {}),
+    );
+    assert.deepEqualTyped(url()[safeParse](data, "input"), failParse("invalid", {}));
   });
 });

--- a/src/validators/url.ts
+++ b/src/validators/url.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  type Failures,
+  type FormInput,
+  failParse,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 import { text } from "./text.ts";
 
 /**
@@ -11,29 +18,36 @@ import { text } from "./text.ts";
  * - `minlength` - Minimum length of the input.
  * - `pattern` - Regular expression pattern to match.
  */
-export function url(attributes?: {
-  required?: false;
-  minlength?: number;
-  maxlength?: number;
-  pattern?: RegExp;
-}): FormInput<string | null> & { asURL(): FormInput<URL | null> };
-export function url(attributes: {
-  required: true;
-  minlength?: number;
-  maxlength?: number;
-  pattern?: RegExp;
-}): FormInput<string> & { asURL(): FormInput<URL> };
+export function url(
+  attributes?: {
+    required?: false;
+    minlength?: number;
+    maxlength?: number;
+    pattern?: RegExp;
+  },
+  failures?: Failures<"type" | "invalid" | "required" | "maxlength" | "minlength" | "pattern">,
+): FormInput<string | null> & { asURL(): FormInput<URL | null> };
+export function url(
+  attributes: {
+    required: true;
+    minlength?: number;
+    maxlength?: number;
+    pattern?: RegExp;
+  },
+  failures?: Failures<"type" | "invalid" | "required" | "maxlength" | "minlength" | "pattern">,
+): FormInput<string> & { asURL(): FormInput<URL> };
 export function url(
   attributes = {},
+  failures: Failures<"type" | "invalid" | "required" | "maxlength" | "minlength" | "pattern"> = {},
 ): FormInput<string | null> & { asURL(): FormInput<URL | null> } {
   return {
     ...methods,
     attributes,
     [safeParse]: (data, name) => {
-      const result = text(attributes)[safeParse](data, name);
+      const result = text(attributes, failures)[safeParse](data, name);
       if (result.success === false) return result;
       if (result.data === null) return succeed(null);
-      if (!URL.canParse(result.data)) return failures.invalid();
+      if (!URL.canParse(result.data)) return failParse("invalid", failures);
       return succeed(result.data);
     },
     asURL() {

--- a/src/validators/week.test.ts
+++ b/src/validators/week.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "../assert.ts";
-import { failures, safeParse, succeed } from "../definitions.ts";
+import { failParse, safeParse, succeed } from "../definitions.ts";
 import { week } from "./week.ts";
 
 describe("week()", async () => {
@@ -30,17 +30,20 @@ describe("week()", async () => {
     data.append("nad", "2024-W00");
     data.append("ok", "2024-W40");
 
-    assert.deepEqualTyped(week()[safeParse](data, "missing"), failures.type());
-    assert.deepEqualTyped(week({ required: true })[safeParse](data, "empty"), failures.required());
-    assert.deepEqualTyped(week()[safeParse](data, "input"), failures.invalid());
-    assert.deepEqualTyped(week()[safeParse](data, "nad"), failures.invalid());
+    assert.deepEqualTyped(week()[safeParse](data, "missing"), failParse("type", {}));
+    assert.deepEqualTyped(
+      week({ required: true })[safeParse](data, "empty"),
+      failParse("required", {}),
+    );
+    assert.deepEqualTyped(week()[safeParse](data, "input"), failParse("invalid", {}));
+    assert.deepEqualTyped(week()[safeParse](data, "nad"), failParse("invalid", {}));
     assert.deepEqualTyped(
       week({ min: "2024-W41" })[safeParse](data, "ok"),
-      failures.min("2024-W41"),
+      failParse("min", {}, { min: "2024-W41" }),
     );
     assert.deepEqualTyped(
       week({ max: "2024-W39" })[safeParse](data, "ok"),
-      failures.max("2024-W39"),
+      failParse("max", {}, { max: "2024-W39" }),
     );
   });
 });

--- a/src/validators/week.ts
+++ b/src/validators/week.ts
@@ -1,4 +1,11 @@
-import { type FormInput, failures, methods, safeParse, succeed } from "../definitions.ts";
+import {
+  failParse,
+  type Failures,
+  type FormInput,
+  methods,
+  safeParse,
+  succeed,
+} from "../definitions.ts";
 
 /**
  * `<input type="week">` form input validator.
@@ -11,29 +18,39 @@ import { type FormInput, failures, methods, safeParse, succeed } from "../defini
  *
  * The output value is a string with the format `yyyy-Www` (e.g. `1999-W01`).
  */
-export function week(attributes?: {
-  required?: false;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-W${number}` | null>;
-export function week(attributes: {
-  required: true;
-  min?: string;
-  max?: string;
-}): FormInput<`${number}-W${number}`>;
+export function week(
+  attributes?: {
+    required?: false;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"required" | "min" | "max" | "invalid" | "type">,
+): FormInput<`${number}-W${number}` | null>;
+export function week(
+  attributes: {
+    required: true;
+    min?: string;
+    max?: string;
+  },
+  failures?: Failures<"required" | "min" | "max" | "invalid" | "type">,
+): FormInput<`${number}-W${number}`>;
 export function week(
   attributes: { required?: boolean; min?: string; max?: string } = {},
+  failures: Failures<"required" | "min" | "max" | "invalid" | "type"> = {},
 ): FormInput<`${number}-W${number}` | null> {
   return {
     ...methods,
     attributes,
     [safeParse]: (data, name) => {
       const value = data.get(name);
-      if (typeof value !== "string") return failures.type();
-      if (value === "") return attributes.required ? failures.required() : succeed(null);
-      if (!/^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/.test(value)) return failures.invalid();
-      if (attributes.min && value < attributes.min) return failures.min(attributes.min);
-      if (attributes.max && value > attributes.max) return failures.max(attributes.max);
+      if (typeof value !== "string") return failParse("type", failures);
+      if (value === "")
+        return attributes.required ? failParse("required", failures) : succeed(null);
+      if (!/^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/.test(value)) return failParse("invalid", failures);
+      if (attributes.min && value < attributes.min)
+        return failParse("min", failures, { min: attributes.min });
+      if (attributes.max && value > attributes.max)
+        return failParse("max", failures, { max: attributes.max });
       return succeed(value as `${number}-W${number}`);
     },
   };


### PR DESCRIPTION
All validators now accept a new parameter that comes last and allows replacing an error message:

```js
const username = fg.text(
  { minlength: 3, pattern: /^\w+$/ },
  {
    // Can be a function or a string
    minlength: ({ minlength }) => `Username must be at least ${minlength} characters long`,
    pattern: "Username can only contain letters, numbers, and underscores",
  }
);
```