### PR TITLE
fix: nudge users to use v-mode regexes instead of u-mode

### DIFF
--- a/.chachalog/HxeKti4H.md
+++ b/.chachalog/HxeKti4H.md
@@ -1,0 +1,5 @@
+---
+formgator: patch
+---
+
+Use the `v` flag for RegExps.

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,9 @@ export { week } from "./validators/week.ts";
 export type { FormInput, ValidationIssue };
 
 const stringifyRegex = (regex: RegExp) => {
-  if (regex.flags !== "u") console.warn("[formgator] RegExp attribute must be written with u flag");
+  // The compiled pattern of an input uses v mode.
+  // https://html.spec.whatwg.org/multipage/input.html#compiled-pattern-regular-expression
+  if (regex.flags !== "v") console.warn("[formgator] RegExp attribute must be written with v flag");
   if (!regex.source.startsWith("^") || !regex.source.endsWith("$"))
     console.warn("[formgator] RegExp attribute must start with ^ and end with $");
   return regex.source.replaceAll(/^\^|\$$/g, "");

--- a/src/validators/email.test.ts
+++ b/src/validators/email.test.ts
@@ -20,7 +20,7 @@ describe("email()", async () => {
       succeed("gautier@example.com"),
     );
     assert.deepEqualTyped(
-      email({ pattern: /^.+@example\.com$/u })[safeParse](data, "input"),
+      email({ pattern: /^.+@example\.com$/v })[safeParse](data, "input"),
       succeed("gautier@example.com"),
     );
     assert.deepEqualTyped(email()[safeParse](data, "empty"), succeed(null));
@@ -29,7 +29,7 @@ describe("email()", async () => {
       succeed(["gautier@example.com", "gautier@example.net"]),
     );
     assert.deepEqualTyped(
-      email({ multiple: true, pattern: /^gautier@.+$/u })[safeParse](data, "multiple"),
+      email({ multiple: true, pattern: /^gautier@.+$/v })[safeParse](data, "multiple"),
       succeed(["gautier@example.com", "gautier@example.net"]),
     );
     assert.deepEqualTyped(email({ multiple: true })[safeParse](data, "empty"), succeed([]));
@@ -65,12 +65,12 @@ describe("email()", async () => {
       failParse("maxlength", {}, { maxlength: 18 }),
     );
     assert.deepEqualTyped(
-      email({ pattern: /^.+@example\.net$/u })[safeParse](data, "ok"),
-      failParse("pattern", {}, { pattern: /^.+@example\.net$/u }),
+      email({ pattern: /^.+@example\.net$/v })[safeParse](data, "ok"),
+      failParse("pattern", {}, { pattern: /^.+@example\.net$/v }),
     );
     assert.deepEqualTyped(
-      email({ multiple: true, pattern: /^.+@example\.net$/u })[safeParse](data, "ok"),
-      failParse("pattern", {}, { pattern: /^.+@example\.net$/u }),
+      email({ multiple: true, pattern: /^.+@example\.net$/v })[safeParse](data, "ok"),
+      failParse("pattern", {}, { pattern: /^.+@example\.net$/v }),
     );
   });
 });

--- a/src/validators/text.test.ts
+++ b/src/validators/text.test.ts
@@ -20,7 +20,7 @@ describe("text()", async () => {
       succeed("hello world!"),
     );
     assert.deepEqualTyped(
-      text({ pattern: /^\w+ \w+!$/u })[safeParse](data, "input"),
+      text({ pattern: /^\w+ \w+!$/v })[safeParse](data, "input"),
       succeed("hello world!"),
     );
     assert.deepEqualTyped(text().trim()[safeParse](data, "trim"), succeed("hello"));
@@ -53,8 +53,8 @@ describe("text()", async () => {
       failParse("maxlength", { maxlength: "11 chars plz" }, { maxlength: 11 }),
     );
     assert.deepEqualTyped(
-      text({ pattern: /^\w+ \w+\?$/u })[safeParse](data, "ok"),
-      failParse("pattern", {}, { pattern: /^\w+ \w+\?$/u }),
+      text({ pattern: /^\w+ \w+\?$/v })[safeParse](data, "ok"),
+      failParse("pattern", {}, { pattern: /^\w+ \w+\?$/v }),
     );
   });
 });


### PR DESCRIPTION
Internally the compiled pattern of inputs is determined using v-mode, which is close to u-mode but not the same. This  better aligns with the standard: https://html.spec.whatwg.org/multipage/input.html#compiled-pattern-regular-expression

As an example, the regex `/^[\p{Script=Latin}--\p{ASCII}]+$/v` matches against "é" in v-mode but just throws in u-mode, and behaves as expected as an input pattern

